### PR TITLE
First/last page

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -139,6 +139,7 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
 
         // get pages
         $pages = $this->getPages();
+        $pages_count = count($pages) - 1;
 
         // get uri pattern for previous/next navigation
         $uri = $this->uri.'?'.$this->settings['url_parameter'].'=%s';
@@ -149,8 +150,10 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
         // extend template variables
         $vars['paginator'] = array(
             'offset'   => $this->offset,
+            'first'    => sprintf($uri, $this->first_page),
             'previous' => ($this->offset > 0) ? sprintf($uri, $current - 1) : '',
-            'next'     => ($this->offset < count($pages) - 1) ? sprintf($uri, $current + 1) : '',
+            'next'     => ($this->offset < $pages_count) ? sprintf($uri, $current + 1) : '',
+            'last'     => sprintf($uri, $this->first_page + $pages_count),
             'pages'    => $this->getPages(),
         );
         \Phile\Registry::set($registry, $vars);

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ return array(
     'url_parameter' => 'page',
 
     /**
+     * Which number to use as first page.
+     *
+     * Set this to 1 or any other integer if you wish to set the first page to
+     * be 1 instead of 0.
+     */
+    'first_page' => 0,
+
+    /**
      * How to sort the posts, this actually uses the same syntax as the one
      * from the Phile core.
      */
@@ -98,12 +106,13 @@ works before proceeding to using it.
 With the default settings, this will sort all the posts out and paginate it
 according to `posts_per_page`. Now you can use in your Twig HTML template:
 
-```html
+```twig
 <ul>
-    <li>You are on page {{ paginator.offset }} of {{ paginator.pages|length - 1}}</li>
     <li>There are {{ paginator.pages[paginator.offset]|length }} posts on this page</li>
-    <li>The url for the next page is {{ paginator.next }}</li>
+    <li>The url for the first page is {{ paginator.first }}</li>
     <li>The url for the previous page is {{ paginator.previous }}</li>
+    <li>The url for the next page is {{ paginator.next }}</li>
+    <li>The url for the last page is {{ paginator.last }}</li>
 </ul>
 
 <p>All the posts for this page are:</p>
@@ -123,10 +132,11 @@ An example output could be:
 
 ```html
 <ul>
-    <li>You are on page 0 of 2</li>
     <li>There are 10 posts on this page</li>
-    <li>The url for the next page is blog?page=1</li>
-    <li>The url for the previous page is</li>
+    <li>The url for the first page is blog?page=1</li>
+    <li>The url for the previous page is blog?page=1</li>
+    <li>The url for the next page is blog?page=3</li>
+    <li>The url for the last page is blog?page=5</li>
 </ul>
 
 ...

--- a/config.php
+++ b/config.php
@@ -21,6 +21,14 @@ return array(
     'url_parameter' => 'page',
 
     /**
+     * Which number to use as first page.
+     *
+     * Set this to 1 or any other integer if you wish to set the first page to
+     * be 1 instead of 0.
+     */
+    'first_page' => 0,
+
+    /**
      * How to sort the posts, this actually uses the same syntax as the one
      * from the Phile core.
      */


### PR DESCRIPTION
This PR introduces the first/last page navigation:

**Allow users to define the first page**

As discussed on issue #5, the user can now define the index to the first page by modifying `first_page` settings in the `config.php`.

**Add first/last page url (twig) variable**

In addition, the following two template variables are added:
1. `paginator.first`  - contains the uri of the first page
2. `paginator.last` - contains the uri of the last page

In this way, the user can now have a full functional pagination like:

```
|<   <   1   [2]   3   >  >|
```
