### PR TITLE
pass Plugin object to Twig

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ return array(
      * Set to 0 or a negative value if you don't want to limit the posts per
      * page.
      */
-    'posts_per_page' => 10,
+    'posts_per_page' => 8,
 
     /**
      * URL parameter to determine the page offset.
@@ -35,7 +35,7 @@ return array(
     'pages_order' => 'meta.date:desc meta.title:asc',
 
     /**
-     * All the paginators.
+     * Filter posts.
      *
      * This is an array where each uri is mapped to a function that will be
      * used for determining whether the page belongs to the same set of posts
@@ -43,19 +43,20 @@ return array(
      *
      * For example:
      *
-     *      '/blog' => function($page) {
+     *      'blog' => function($page) {
      *          return strpos($page->getUrl(), 'blog/') !== false;
      *      }
      *
      * When visiting the /blog page, all posts that contains a 'blog/' (with
      * trailing slashes) in its uri will be paginated.
      *
-     * Regular expressions are allowed (note that the slashes will be escaped).
+     * Check out `lib/Phile/Model/Page.php` for a list of member functions
+     * availble for the `$page` argument.
      *
-     * Also note that '/' indicates the root page.
-     *
-     * Optionally, you can consult `lib/Phile/Model/Page.php` for a list of
-     * member functions availble for the `$page` argument.
+     * By default it paginates all the pages that's in the uri's folder (but
+     * the index file). For example the uri: `blog/project/` will paginate all
+     * the files under the `blog/project/` folder (recursively), with the
+     * exception of `index` files.
      */
     'paginators' => array(
     ),


### PR DESCRIPTION
Instead of creating a new variable to the `templateVar` engine, the plugin itself is passed to make it easier to design a (Twig) HTML template.

This makes it easy to loop over the pages:

``` twig
{% for paginator.pages %}
{% endfor %}
```

instead of the strange looking:

``` twig
{% for paginator[paginator.offset] %}
{% endfor %}
```

Also consequently apply this for the previous/next - first/last navigation:

``` twig
{% for paginator.previous.pages %}
{% endfor %}

{% for paginator.next.pages %}
{% endfor %}

{% for paginator.first.pages %}
{% endfor %}

{% for paginator.last.pages %}
{% endfor %}
```

Because chaining 'em is awesome!

**Important**
After merge this repo needs to be upgraded to v1.0.0 since it breaks with the old version.
