### PR TITLE
Fix for exception 'missing index content_dir'

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -110,7 +110,11 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
         $filter = array_key_exists($uri, $paginators) ? $paginators[$uri] : function($page) {
             return strpos($page->getUrl(), self::$uri) !== false and strpos($page->getFilePath(), 'index') === false;
         };
-		$repo = new \Phile\Repository\Page($this->settings);
+        //$repo = new \Phile\Repository\Page($this->settings);
+        //   $this->settings does not contain index 'content_dir',
+        //   causing an exception to be raised in findAll() below.
+        //   Omitting parameter $this->settings from the call fixes it.
+        $repo = new \Phile\Repository\Page();
         $pages = array_filter($repo->findAll()->toArray(), $filter);
 
         // chunk'em up if neccessary


### PR DESCRIPTION
I cloned the current version of PhileCMS and cloned philePaginator as a plugin. The plugin broke my previously working test site, causing an exception 'no index content_dir' on all pages other than index.md. I tracked it to line 113:
`$repo = new \Phile\Repository\Page($this->settings);`
It seems that $this->settings does not contain the necessary config setting. Replacing that line with:
`$repo = new \Phile\Repository\Page();`
seems to have resolved the issue.
